### PR TITLE
백신 DB 테이블 생성

### DIFF
--- a/myVaccine/WebContent/resources/sql/institution.sql
+++ b/myVaccine/WebContent/resources/sql/institution.sql
@@ -1,3 +1,5 @@
+drop table institution;
+
 create table if not exists institution(
 	p_appDate DATE,
 	p_instAddress1 VARCHAR(50),
@@ -6,14 +8,14 @@ create table if not exists institution(
 	p_instAddress4 VARCHAR(50),
 	p_instName VARCHAR(50),
 	p_instPhone VARCHAR(20),
-	p_instWorkHour TEXT,
-	p_modslnStock LONG,
-	p_pfislnStock LONG
+	p_instWorkHour TEXT
 )default charset=utf8;
-
 
 select * from institution;
 
-/* 테스트를 위한 데이터 입력 */
-insert into institution values('2021-09-03', '대구광역시', '동구', '동촌로', '79', '동구보건소','053-662-3201','평일 09:00 - 18:00',30, 30);
+/* 기관 이름(p_instName)을 primary key로 지정 */
+alter table institution add primary key(p_instName);
 
+/* 테스트를 위한 데이터 입력 */
+/*insert into institution values('2021-09-03', '대구광역시', '동구', '동촌로', '79', '동구보건소','053-662-3201','평일 09:00 - 18:00',30, 30);*/
+insert into institution values('2021-09-03', '대구광역시', '동구', '동촌로', '79', '동구보건소','053-662-3201','평일 09:00 - 18:00');

--- a/myVaccine/WebContent/resources/sql/institution.sql
+++ b/myVaccine/WebContent/resources/sql/institution.sql
@@ -17,5 +17,4 @@ select * from institution;
 alter table institution add primary key(p_instName);
 
 /* 테스트를 위한 데이터 입력 */
-/*insert into institution values('2021-09-03', '대구광역시', '동구', '동촌로', '79', '동구보건소','053-662-3201','평일 09:00 - 18:00',30, 30);*/
 insert into institution values('2021-09-03', '대구광역시', '동구', '동촌로', '79', '동구보건소','053-662-3201','평일 09:00 - 18:00');

--- a/myVaccine/WebContent/resources/sql/vaccine.sql
+++ b/myVaccine/WebContent/resources/sql/vaccine.sql
@@ -14,7 +14,6 @@ select * from vaccine;
 /* 기관 이름을 FK로 지정 */
 alter table vaccine add foreign key(vac_inst) references institution(p_instName);
 
-
 /* 테스트를 위한 데이터 입력 */
 insert into vaccine values('동구보건소', '09:00:00', 30, 25, 30, 30);
 insert into vaccine values('동구보건소', '10:00:00', 30, 30, 30, 30);

--- a/myVaccine/WebContent/resources/sql/vaccine.sql
+++ b/myVaccine/WebContent/resources/sql/vaccine.sql
@@ -1,0 +1,20 @@
+drop table vaccine;
+
+create table if not exists vaccine(
+	vac_inst VARCHAR(50) NOT NULL, /* 접종 기관 */
+	vac_time TIME, /* 접종 가능 시간 */
+	vac_mdnTotal INT(2), /* 시간별 모더나 총량 */
+	vac_mdnUse INT(2), /* 시간별 모더나 사용량 */
+	vac_pfzrTotal INT(2), /* 시간별 화이자 총량 */
+	vac_pfzrUse INT(2) /* 시간별 화이자 사용량 */
+)default charset=utf8;
+
+select * from vaccine;
+
+/* 기관 이름을 FK로 지정 */
+alter table vaccine add foreign key(vac_inst) references institution(p_instName);
+
+
+/* 테스트를 위한 데이터 입력 */
+insert into vaccine values('동구보건소', '09:00:00', 30, 25, 30, 30);
+insert into vaccine values('동구보건소', '10:00:00', 30, 30, 30, 30);


### PR DESCRIPTION
시간별 백신의 총량과 사용량을 입력할 백신 DB 별도 생성

- 기관 이름(FK)
- 접종 시간
- 접종 시간 내에 사용할 수 있는 모더나 총량
- 접종 시간 내에 사용된 모더나 백신의 양
- 접종 시간 내에 사용할 수 있는 화이자 총량
- 접종 시간 내에 사용된 화이자 백신의 양

* 기존 의료기관 DB에 있던 모더나, 화이자 재고량에 대한 항목은 삭제